### PR TITLE
Added bufio writing

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -3,6 +3,7 @@ package dvara
 import (
 	"errors"
 	"fmt"
+	"bufio"
 	"io"
 )
 
@@ -129,6 +130,7 @@ func readHeader(r io.Reader) (*messageHeader, error) {
 	if _, err := io.ReadFull(r, b); err != nil {
 		return nil, err
 	}
+
 	h := messageHeader{}
 	h.FromWire(b)
 	return &h, nil
@@ -136,14 +138,16 @@ func readHeader(r io.Reader) (*messageHeader, error) {
 
 // copyMessage copies reads & writes an entire message.
 func copyMessage(w io.Writer, r io.Reader) error {
+	buf := bufio.NewWriter(w)
 	h, err := readHeader(r)
 	if err != nil {
 		return err
 	}
-	if err := h.WriteTo(w); err != nil {
+	if err := h.WriteTo(buf); err != nil {
 		return err
 	}
-	_, err = io.CopyN(w, r, int64(h.MessageLength-headerLen))
+	_, err = io.CopyN(buf, r, int64(h.MessageLength-headerLen))
+	buf.Flush()
 	return err
 }
 

--- a/response_rewriter.go
+++ b/response_rewriter.go
@@ -332,15 +332,16 @@ func (r *ReplyRW) WriteOne(client io.Writer, h *messageHeader, prefix replyPrefi
 		return err
 	}
 
+    buf := bufio.NewWriter(client)
 	h.MessageLength = h.MessageLength - oldDocLen + int32(len(newDoc))
 	parts := [][]byte{h.ToWire(), prefix[:], newDoc}
 	for _, p := range parts {
-		if _, err := client.Write(p); err != nil {
+		if _, err := buf.Write(p); err != nil {
 			return err
 		}
 	}
 
-	return nil
+    return buf.Flush()
 }
 
 type isMasterResponse struct {


### PR DESCRIPTION
I modified the code to use `bufio` in spots.  I noticed when looking at the packets in Wireshark that there were lots of [TCP segment of a reassembled PDU] messages.  Essentially what is/was happening is that the old code would send a part at a time, which in some instances was only 16 bytes.  Since the TCP/IP header is 40 bytes, and the Ethernet header could be up to 30 bytes for Wi-Fi, you're sending a decent amount of overhead for really small packets. 
