### PR TITLE
Fix runtime exceptions; Add "-listen=..." parameter

### DIFF
--- a/cmd/dvara/main.go
+++ b/cmd/dvara/main.go
@@ -27,6 +27,7 @@ func Main() error {
 	clientIdleTimeout := flag.Duration("client_idle_timeout", 60*time.Minute, "idle timeout for client connections")
 	getLastErrorTimeout := flag.Duration("get_last_error_timeout", time.Minute, "timeout for getLastError pinning")
 	maxConnections := flag.Uint("max_connections", 100, "maximum number of connections per mongo")
+	listenAddr := flag.String("listen", "", "address for listening, for example, 127.0.0.1")
 	portStart := flag.Int("port_start", 6000, "start of port range")
 	portEnd := flag.Int("port_end", 6010, "end of port range")
 	addrs := flag.String("addrs", "localhost:27017", "comma separated list of mongo addresses")
@@ -35,6 +36,7 @@ func Main() error {
 
 	replicaSet := dvara.ReplicaSet{
 		Addrs:               *addrs,
+		ListenAddr:          *listenAddr,
 		PortStart:           *portStart,
 		PortEnd:             *portEnd,
 		MessageTimeout:      *messageTimeout,

--- a/cmd/dvara/main.go
+++ b/cmd/dvara/main.go
@@ -25,12 +25,15 @@ func main() {
 func Main() error {
 	messageTimeout := flag.Duration("message_timeout", 2*time.Minute, "timeout for one message to be proxied")
 	clientIdleTimeout := flag.Duration("client_idle_timeout", 60*time.Minute, "idle timeout for client connections")
+	serverIdleTimeout := flag.Duration("server_idle_timeout", 60*time.Minute, "idle timeout for server connections")
 	getLastErrorTimeout := flag.Duration("get_last_error_timeout", time.Minute, "timeout for getLastError pinning")
 	maxConnections := flag.Uint("max_connections", 100, "maximum number of connections per mongo")
+	maxPerClientConnections := flag.Uint("max_per_client_connections", 500, "maximum number of connections per client")
 	listenAddr := flag.String("listen", "", "address for listening, for example, 127.0.0.1")
 	portStart := flag.Int("port_start", 6000, "start of port range")
 	portEnd := flag.Int("port_end", 6010, "end of port range")
 	addrs := flag.String("addrs", "localhost:27017", "comma separated list of mongo addresses")
+	poolSize := flag.Uint("pool_size", 5, "pool size for server connections")
 
 	flag.Parse()
 
@@ -41,8 +44,11 @@ func Main() error {
 		PortEnd:             *portEnd,
 		MessageTimeout:      *messageTimeout,
 		ClientIdleTimeout:   *clientIdleTimeout,
+		ServerIdleTimeout:   *serverIdleTimeout,
 		GetLastErrorTimeout: *getLastErrorTimeout,
+		ServerClosePoolSize: *poolSize,
 		MaxConnections:      *maxConnections,
+		MaxPerClientConnections: *maxPerClientConnections,
 	}
 
 	var statsClient stats.HookClient

--- a/common_test.go
+++ b/common_test.go
@@ -43,6 +43,7 @@ type Harness struct {
 func newHarnessInternal(url string, s stopper, t testing.TB) *Harness {
 	replicaSet := ReplicaSet{
 		Addrs:                   url,
+		ListenAddr:              "",
 		PortStart:               2000,
 		PortEnd:                 3000,
 		MaxConnections:          5,

--- a/replica_set.go
+++ b/replica_set.go
@@ -55,6 +55,10 @@ type ReplicaSet struct {
 	// not reachable.
 	Addrs string
 
+	// Where to listen for clients.
+	// "0.0.0.0" means public service, "127.0.0.1" means localhost only.
+	ListenAddr string
+
 	// PortStart and PortEnd define the port range within which proxies will be
 	// allocated.
 	PortStart int
@@ -294,7 +298,7 @@ func (r *ReplicaSet) proxyHostname() string {
 
 func (r *ReplicaSet) newListener() (net.Listener, error) {
 	for i := r.PortStart; i <= r.PortEnd; i++ {
-		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", i))
+		listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", r.ListenAddr, i))
 		if err == nil {
 			return listener, nil
 		}


### PR DESCRIPTION
1) Currently Dvara listens on 0.0.0.0.
But it should be useful to restrict listening to localhost or selected interfaces only.
New "-listen=x.x.x.x" param adds such possibility.

2) Fix runtime exception on the first incoming connection because connection object misses some required fields.
