### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang
+
+RUN \
+  go get github.com/facebookgo/dvara/cmd/dvara
+
+ENTRYPOINT [ "bin/dvara" ]
+CMD [ "--help" ]


### PR DESCRIPTION
Add Dockerfile to enable image building.
By now, I use the official Golang image, default tag (minimalist 'alpine' lacks git). More info at https://hub.docker.com/_/golang/

Just installing via `go get`. Default option to `dvara` if none provided is `--help` to show usage. 

Build:

```
$ docker build -t dvara .
```

Example run (assuming an already running MongoDB container named `mongo`):

```
$ docker run --dit --name dvara -p 6000-6010:6000-6010 --link mongo dvara -addrs mongo:27017 -dvara.proxy-all
```

Optional improvement to come:
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process.
